### PR TITLE
try with latin-1 on decode failure

### DIFF
--- a/getmailcore/_retrieverbases.py
+++ b/getmailcore/_retrieverbases.py
@@ -94,9 +94,13 @@ else:
                 try:
                     ltsutf = codecs.decode(lts)
                     return ltsutf
-                except UnicodeDecodeError as de:
-                    print(lts)
-                    raise de
+                except UnicodeDecodeError:
+                    try:
+                        ltsutf = codecs.decode(lts,'latin-1')
+                        return ltsutf
+                    except UnicodeDecodeError as de:
+                        print(lts)
+                        raise de
         return lts
 
 # If we have an ssl module:


### PR DESCRIPTION
Hey, thanks for this, I depend on getmail for my personal email, and am really thankful that you have done this python 3 work.

I noticed that sometimes decoding fails, and that trying with latin-1 allows the getmail to continue. Not sure if this is the best way to solve this problem, but works on my server.
